### PR TITLE
Publish Homebrew tap from release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -541,3 +541,172 @@ jobs:
           draft: ${{ steps.release.outputs.draft }}
           prerelease: ${{ steps.release.outputs.prerelease }}
           overwrite: true
+
+  publish-homebrew-tap:
+    name: Update Homebrew tap
+    needs: publish-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # Update the public tap only for real public releases.
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.draft == false && inputs.prerelease == false) }}
+
+    steps:
+      - name: Resolve release tag
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download macOS packaged assets
+        uses: actions/download-artifact@v8
+        with:
+          pattern: packaged-macos-*
+          path: dist
+          merge-multiple: true
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v7
+        with:
+          repository: nehemiaharchives/homebrew-bbl
+          ref: master
+          path: tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Generate combined Homebrew formula
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${{ steps.release.outputs.tag }}"
+
+          arm_asset="bbl-$tag-macos-arm64-homebrew.tar.gz"
+          x64_asset="bbl-$tag-macos-x64-homebrew.tar.gz"
+
+          test -f "dist/$arm_asset"
+          test -f "dist/$x64_asset"
+
+          arm_sha="$(sha256sum "dist/$arm_asset" | awk '{print $1}')"
+          x64_sha="$(sha256sum "dist/$x64_asset" | awk '{print $1}')"
+
+          mkdir -p tap/Formula
+
+          cat > tap/Formula/bbl.rb <<EOF
+          class Bbl < Formula
+            desc "Read/search Holy Bible in your terminal"
+            homepage "https://github.com/nehemiaharchives/bbl"
+            version "$tag"
+            license "Apache-2.0"
+
+            on_macos do
+              on_arm do
+                url "https://github.com/nehemiaharchives/bbl/releases/download/$tag/$arm_asset"
+                sha256 "$arm_sha"
+              end
+
+              on_intel do
+                url "https://github.com/nehemiaharchives/bbl/releases/download/$tag/$x64_asset"
+                sha256 "$x64_sha"
+              end
+            end
+
+            def install
+              libexec.install "bbl", "bbl-search-common"
+              (prefix/"packs").install "webus.zip"
+
+              bash_completion.install "bbl.bash" => "bbl"
+              zsh_completion.install "_bbl"
+              fish_completion.install "bbl.fish"
+
+              (bin/"bbl").write <<~SH
+                #!/bin/bash
+                set -e
+                mkdir -p "\$HOME/.bbl/bin" "\$HOME/.bbl/packs"
+
+                if ! cmp -s "#{libexec}/bbl-search-common" "\$HOME/.bbl/bin/bbl-search-common"; then
+                  install -m 0755 "#{libexec}/bbl-search-common" "\$HOME/.bbl/bin/bbl-search-common"
+                fi
+
+                if ! cmp -s "#{prefix}/packs/webus.zip" "\$HOME/.bbl/packs/webus.zip"; then
+                  install -m 0644 "#{prefix}/packs/webus.zip" "\$HOME/.bbl/packs/webus.zip"
+                fi
+
+                exec "#{libexec}/bbl" "\$@"
+              SH
+            end
+
+            test do
+              assert_match(/God|god/, shell_output("#{bin}/bbl john 3:16"))
+              assert_match(/God|god/, shell_output("#{bin}/bbl search God limit 1"))
+            end
+
+            def caveats
+              <<~EOS
+                bbl shell completions installed:
+                  bash: source #{bash_completion}/bbl
+                  zsh:  autoload -Uz compinit && compinit
+                  fish:  auto-sourced from #{fish_completion}/bbl.fish
+              EOS
+            end
+          end
+          EOF
+
+          sed -i 's/^          //' tap/Formula/bbl.rb
+          ruby -c tap/Formula/bbl.rb
+
+      - name: Add tap README
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cat > tap/README.md <<'EOF'
+          # homebrew-bbl
+
+          Homebrew tap for [bbl](https://github.com/nehemiaharchives/bbl), a command line tool to read and search the Holy Bible.
+
+          ## Install
+
+          ```bash
+          brew install nehemiaharchives/bbl/bbl
+          ```
+
+          Or:
+
+          ```bash
+          brew tap nehemiaharchives/bbl
+          brew install bbl
+          ```
+
+          ## Test
+
+          ```bash
+          bbl john 3:16
+          bbl search God limit 1
+          ```
+          EOF
+
+          sed -i 's/^          //' tap/README.md
+
+      - name: Commit and push tap update
+        working-directory: tap
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add Formula/bbl.rb README.md
+
+          if git diff --cached --quiet; then
+            echo "Homebrew tap already up to date."
+            exit 0
+          fi
+
+          git commit -m "Update bbl formula to ${{ steps.release.outputs.tag }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ state, run ```bbl list translations```.
 
 Download packages from the [v2.0 release](https://github.com/nehemiaharchives/bbl/releases/tag/v2.0).
 
+### Homebrew
+
+```bash
+brew install nehemiaharchives/bbl/bbl
+```
+
 |       | deb | rpm | Arch | Alpine | Nix | macOS | Windows |
 |-------| --- | --- | ---- | ------ | --- | ----- | ------- |
 | x64   | [deb](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-amd64.deb) | [rpm](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-x86_64.rpm) | [pkg.tar.zst](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-x86_64.pkg.tar.zst) | [apk](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-x86_64.apk) | [flake](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-x64-nix-flake.tar.gz) | [pkg](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-macos-x64.pkg) | [msi](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-2.0-windows-x64.msi) |

--- a/RELEASE_NOET_v2.0.md
+++ b/RELEASE_NOET_v2.0.md
@@ -1,0 +1,58 @@
+* bbl is moved from Kotlin/JVM to Kotlin/Native to produce **single binary**
+* bbl reading commands will be single binary executable + bbl pack zip files contains text and lucene index, and bbl search command will be dispatched to search specific single binary produced for each language(s) according to lucene language analyzer library boundary
+* installs only one default bible translation `webus` (World English Bible) with one default search binary `bbl-search-common`, then users run `bbl list` to see what's available for download, then installs additional bbl packs by `bbl install kjv` just like package manager, `bbl uninstall kjv` also supported. This is because we increased number of languages/bible translations significantly, and having single fat installation over 300 MB with many unused languages does not make sense.
+* bbl packs will be stored at `$HOME/.bbl/packs/webus.zip` and search binaries will be stored at `$HOME/.bbl/bin/bbl-search-common`
+* search binaries are installed automatically as dependency of bbl packs, and executed as background process, so users will not see/use them, they are split into multiple just for reducing disk space.
+* search engine library switched from [Apache Lucene](https://github.com/apache/lucene) to [lucene-kmp](https://github.com/nehemiaharchives/lucene-kmp) which was ported from Java to KMP **just for bbl**. bbl will **dogfood** lucene-kmp and both will be improved together
+
+## New features
+- `bbl john 3:16 in es` - specify translation by iso 2 letter language code e.g.  `es`, `de`, `fr`  or language names e.g. `Spanish`, `German`, `French`
+- `bbl john 3:16 in es de fr` - compare multiple translation by space separated list of translation code, language code, language names, the display layout can be changed by verse or by translation via `bbl config compareBy verse` and `bbl config compareBy block`
+- `bbl search Jesus Christ in en es de fr` - compare search results of `en` bible with other languages
+- `bbl list categories` and `bbl search [term] in [category code]` to narrow down search result by e.g. `nt`, `ot`, `prophets`, `gospels`, `paul`, `johns writings`
+- `bbl history` to see command history. can be filtered only reading/search/config history by `bbl history read`, `bbl history search`, `bbl history config`, history file is in `$HOME/.bbl/history.json`, `bbl config historyEnabled false` to disable recording history, `bbl config historyFormat [format]` to format in `command`, `commandDatetime`, `commandDatetimeTimezone`
+- `bbl config header true` to show book name and chapter name on top of currently reading text output
+- `bbl config [key] to show current config value. `bbl config [key] [value]` to change config value of a key
+- `bbl s Jesus` as shortcut of `bbl search Jesus`, in other way `r` for `rand`, `h` for `history`, `ls` for `list`, `c` for `config`
+
+## Languages supported:
+```
+WEBUS  | World English Bible               | World English Bible              | English    | 2000 | Available | Public Domain
+KJV    | King James Version                | King James Version               | English    | 1611 | Available | Public Domain
+RVR09  | Reina-Valera                      | Reina-Valera                     | Spanish    | 1909 | Available | Public Domain
+TB     | Brazilian Translation             | Tradução Brasileira              | Portuguese | 1917 | Available | Public Domain
+DELUT  | Luther Bible                      | Lutherbibel                      | German     | 1912 | Available | Public Domain
+LSG    | Louis Segond                      | Bible Segond                     | French     | 1910 | Available | Public Domain
+SINOD  | Russian Synodal Bible             | Синодальный перевод              | Russian    | 1876 | Available | Public Domain
+SVRJ   | Statenvertaling Jongbloed edition | Statenvertaling Jongbloed-editie | Dutch      | 1888 | Available | Public Domain
+RDV24  | Revised Diodati Version           | Versione Diodati Riveduta        | Italian    | 1924 | Available | Public Domain
+UBG    | Updated Gdansk Bible              | Uwspółcześniona Biblia gdańska   | Polish     | 2017 | Available | © 2017 Fundacja Wrota Nadziei (Non-commercial)
+UBIO   | Ukrainian Bible, Ivan Ogienko     | Біблія в пер. Івана Огієнка      | Ukrainian  | 1962 | Available | CC BY-SA 4.0 © 1962 Українське Біблійне Товариство
+SVEN   | Svenska 1917                      | 1917 års kyrkobibel              | Swedish    | 1917 | Available | Public Domain
+CUNP   | Chinese Union Version             | 新標點和合本                     | Chinese    | 1919 | Available | Public Domain
+KRV    | Korean Revised Version            | 개역한글                         | Korean     | 1961 | Available | Public Domain
+JC     | Japanese Colloquial Bible         | 口語訳                           | Japanese   | 1955 | Available | Public Domain
+ABTAG  | Ang Biblia                        | Ang Biblia                       | Tagalog    | 1905 | Available | Public Domain
+AYT    | The Opened Bible                  | Alkitab Yang Terbuka             | Indonesian | 2024 | Available | CC BY-NC-SA 4.0 © 2011-2024 YLSA-AYT
+KTTV   | Vietnamese Bible 1925             | Kinh Thánh Tiếng Việt            | Vietnamese | 1925 | Available | Public Domain
+TH1971 | Thai Bible 1925                   | พระคริสตธรรมคัมภีร์ ฉบับ1971          | Thai       | 1971 | Available | Public Domain
+IRVHIN | Indian Revised Version - Hindi    | इंडियन रिवाइज्ड वर्जन - हिंदी             | Hindi      | 2019 | Available | CC BY-SA 4.0 © 2019 Bridge Connectivity Solutions
+IRVBEN | Indian Revised Version - Bengali  | ইন্ডিয়ান রিভাইজড ভার্সন - বেঙ্গলী         | Bengali    | 2019 | Available | CC BY-SA 4.0 © 2019 Bridge Connectivity Solutions
+IRVMAR | Indian Revised Version - Marathi  | इंडियन रीवाइज्ड वर्जन - मराठी            | Marathi    | 2019 | Available | CC BY-SA 4.0 © 2019 Bridge Connectivity Solutions
+IRVTEL | Indian Revised Version - Telugu   | ఇండియన్ రివైజ్డ్ వెర్షన్ - తెలుగు         | Telugu     | 2019 | Available | CC BY-SA 4.0 © 2019 Bridge Connectivity Solutions
+IRVTAM | Indian Revised Version - Tamil    | இண்டியன் ரிவைஸ்டு வெர்ஸன் - தமிழ்    | Tamil      | 2019 | Available | CC BY-SA 4.0 © 2019 Bridge Connectivity Solutions
+IRVGUJ | Indian Revised Version - Gujarati | ઇન્ડિયન રીવાઇઝ્ડ વર્ઝન ગુજરાતી           | Gujarati   | 2019 | Available | CC BY-SA 4.0 © 2019 Bridge Connectivity Solutions
+IRVURD | Indian Revised Version - Urdu     | इंडियन रिवाइज्ड वर्जन - उर्दू              | Urdu       | 2019 | Available | CC BY-SA 4.0 © 2019 Bridge Connectivity Solutions
+NPIULB | Nepali Unlocked Literal Bible     | पवित्र बाइबल                        | Nepali     | 2019 | Available | CC BY-SA 4.0 © 2019 Door43 World Missions Community
+```
+
+## Supported platforms
+- Ubuntu/Debian family: [deb](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-amd64.deb) x64
+- Debian arm64, Raspberry Pi, Nvidia DGX Spark: [deb](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-arm64.deb) arm64
+- Fedora and other RHEL family: [rpm](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-x86_64.rpm) x64
+- Arch Linux: [pkg.tar.zst](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-x86_64.pkg.tar.zst) x64
+- NixOS: [flake](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-x64-nix-flake.tar.gz) x64
+- Alpine Linux: [apk](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-x86_64.apk) x64, [apk](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-linux-aarch64.apk) arm64
+- Apple Silicon: [pkg](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-macos-arm64.pkg) arm64
+- Intel Mac: [pkg](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-v2.0-macos-x64.pkg) x64
+- Windows: [msi](https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-2.0-windows-x64.msi) x64


### PR DESCRIPTION
Adds a post-release job that updates nehemiaharchives/homebrew-bbl with a combined macOS Homebrew formula for Apple Silicon and Intel archives.