### PR TITLE
Clarify Homebrew tap install docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -675,13 +675,6 @@ jobs:
           brew install nehemiaharchives/bbl/bbl
           ```
 
-          Or:
-
-          ```bash
-          brew tap nehemiaharchives/bbl
-          brew install bbl
-          ```
-
           ## Test
 
           ```bash


### PR DESCRIPTION
Removes the two-step brew tap / brew install bbl instruction from the generated tap README so users use the fully qualified install command and avoid Homebrew's untrusted tap warning.